### PR TITLE
suavex_call for anvil

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "axum",
+ "base64 0.21.7",
  "bytes",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,18 +52,10 @@ serde_json.opt-level = 3
 alloy-dyn-abi.opt-level = 3
 alloy-json-abi.opt-level = 3
 alloy-primitives.opt-level = 3
-alloy-sol-type-parser.opt-level = 3
 alloy-sol-types.opt-level = 3
 hashbrown.opt-level = 3
-keccak.opt-level = 3
-revm-interpreter.opt-level = 3
-revm-precompile.opt-level = 3
 revm-primitives.opt-level = 3
 revm.opt-level = 3
-ruint.opt-level = 3
-sha2.opt-level = 3
-sha3.opt-level = 3
-tiny-keccak.opt-level = 3
 
 # fuzzing
 proptest.opt-level = 3
@@ -71,9 +63,6 @@ foundry-evm-fuzz.opt-level = 3
 
 # forking
 axum.opt-level = 3
-
-# keystores
-scrypt.opt-level = 3
 
 # Local "release" mode, more optimized than dev but much faster to compile than release.
 [profile.local]
@@ -103,18 +92,12 @@ codegen-units = 1
 # Override packages which aren't perf-sensitive for faster compilation speed.
 [profile.release.package]
 mdbook.opt-level = 1
-protobuf.opt-level = 1
 rusoto_core.opt-level = 1
-rusoto_credential.opt-level = 1
 rusoto_kms.opt-level = 1
 toml_edit.opt-level = 1
-trezor-client.opt-level = 1
 
 [workspace.dependencies]
 anvil = { path = "crates/anvil" }
-cast = { path = "crates/cast" }
-chisel = { path = "crates/chisel" }
-forge = { path = "crates/forge" }
 
 forge-doc = { path = "crates/doc" }
 forge-fmt = { path = "crates/fmt" }
@@ -147,7 +130,6 @@ revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev =
 ethers = { version = "2.0", default-features = false }
 ethers-core = { version = "2.0", default-features = false }
 ethers-contract = { version = "2.0", default-features = false }
-ethers-contract-abigen = { version = "2.0", default-features = false }
 ethers-providers = { version = "2.0", default-features = false }
 ethers-signers = { version = "2.0", default-features = false }
 ethers-middleware = { version = "2.0", default-features = false }
@@ -159,7 +141,6 @@ alloy-eips = { git = "https://github.com/alloy-rs/alloy" }
 alloy-genesis = { git = "https://github.com/alloy-rs/alloy" }
 alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy" }
 alloy-network = { git = "https://github.com/alloy-rs/alloy" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy" }
 alloy-providers = { git = "https://github.com/alloy-rs/alloy" }
 alloy-pubsub = { git = "https://github.com/alloy-rs/alloy" }
 alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy" }
@@ -174,7 +155,6 @@ alloy-primitives = { version = "0.6.3", features = ["getrandom"] }
 alloy-dyn-abi = "0.6.3"
 alloy-json-abi = "0.6.3"
 alloy-sol-types = "0.6.3"
-syn-solidity = "0.6.3"
 alloy-chains = "0.1"
 
 alloy-rlp = "0.3.3"
@@ -192,7 +172,6 @@ hex = { package = "const-hex", version = "1.6", features = ["hex"] }
 itertools = "0.11"
 jsonpath_lib = "0.3"
 pretty_assertions = "1.4"
-protobuf = "=3.2.0"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -84,6 +84,7 @@ ctrlc = { version = "3", optional = true }
 fdlimit = { version = "0.3", optional = true }
 clap_complete_fig = "4"
 ethereum-forkid = "0.12"
+base64.workspace = true
 
 [dev-dependencies]
 ethers = { workspace = true, features = ["abigen"] }

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -170,6 +170,9 @@ pub enum EthRequest {
         #[cfg_attr(feature = "serde", serde(default))] Option<StateOverride>,
     ),
 
+    #[cfg_attr(feature = "serde", serde(rename = "suavex_call"))]
+    SuavexCall(Address, String),
+
     #[cfg_attr(feature = "serde", serde(rename = "eth_createAccessList"))]
     EthCreateAccessList(
         TransactionRequest,


### PR DESCRIPTION
enables suapp devs to use anvil as the eth provider for your suave mevm, forking any chain (e.g. eth mainnet) to test your suapps locally.

## instructions

build this version of anvil and run it, then send a curl request to test:
```sh
cargo build --bin anvil
export FORK_URL=https://eth-goerli.g.alchemy.com/v2/YOUR_KEY_HERE
./target/debug/anvil --chain-id 5 -f $FORK_URL -p 8555
# call uniswapV2 router's `getAmountOut`
# note: curl, jq, base64, and hexdump are required
curl -s -X POST --data '{"jsonrpc":"2.0","method":"suavex_call","params":["0x7a250d5630b4cf539739df2c5dacb4c659f2488d", "BU1Q1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABpaWlpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEJCQkJCQkIAAAAAAAAAAAAAAAAAAAAAAAAAABMTExMTExMTExMTEw=="],"id":1}' -H "Content-Type: application/json" http://localhost:8555 | jq -r .result | base64 -d | hexdump -v -e '/1 "%02x"'
```

in another terminal, run suave devnet with the `--suave.eth.remote_endpoint` flag to connect it to anvil:
```sh
# in suave-geth/
./build/bin/suave \
    --dev \
    --dev.gaslimit=30000000 \
    --http \
    --http.port=8545 \
    --http.vhosts='*' \
    --http.corsdomain='*' \
    --ws \
    --ws.origins='*' \
    --datadir=./suave/devenv/data \
    --keystore=./suave/devenv/suave-ex-node/keystore \
    --unlock=0xB5fEAfbDD752ad52Afb7e1bD2E40432A485bBB7F \
    --password=./suave/devenv/suave-ex-node/password.txt \
    --suave.eth.remote_endpoint=http://localhost:8555
```

then write SUAVE-enabled smart contracts that use `suavex_`-reliant precompiles:
```solidity
library UniV2Swop {
    address public constant router = 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;

    /// Returns market price sans fees.
    function getAmountOut(
        uint256 amountIn,
        uint256 reserveIn,
        uint256 reserveOut
    ) internal view returns (uint256 price) {
        bytes memory result = Suave.ethcall(
            router,
            abi.encodeWithSignature(
                "getAmountOut(uint256,uint256,uint256)",
                amountIn,
                reserveIn,
                reserveOut
            )
        );
        require(result.length > 0, "UniV2Swop: no result");
        (price) = abi.decode(result, (uint256));
    }
}
```

write `SuaveEnabled` tests with forge:
```solidity
function testGetAmountOut() public {
    uint256 amountIn = 0x69696969;
    uint256 reserveIn = 0x42424242424242;
    uint256 reserveOut = 0x131313131313131313131313;
    uint256 amountOut = UniV2Swop.getAmountOut(
        amountIn,
        reserveIn,
        reserveOut
    );
    assertEq(amountOut, 558102013055677511204);
}
```